### PR TITLE
安定性の向上

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "com.freshdigitable.ohlplayer"
         minSdkVersion 16
@@ -33,6 +33,6 @@ dependencies {
     compile 'com.google.android.exoplayer:exoplayer:r2.3.1'
     compile "com.android.support:appcompat-v7:$supportLibVer"
     compile "com.android.support:recyclerview-v7:$supportLibVer"
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta2'
+    compile 'com.android.support.constraint:constraint-layout:1.0.2'
     testCompile 'junit:junit:4.12'
 }

--- a/app/src/main/java/com/freshdigitable/ohlplayer/AudioChannels.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/AudioChannels.java
@@ -1,10 +1,13 @@
 package com.freshdigitable.ohlplayer;
 
+import android.util.Log;
+
 /**
  * Created by akihit on 2017/05/14.
  */
 
 public class AudioChannels {
+  private static final String TAG = AudioChannels.class.getSimpleName();
   private final int[] chL;
   private final int[] chR;
 
@@ -22,7 +25,8 @@ public class AudioChannels {
   }
 
   private void add(int[] adderL, int[] adderR) {
-    for (int i = 0; i < adderL.length; i++) {
+    int size = Math.min(chL.length, adderL.length);
+    for (int i = 0; i < size; i++) {
       this.chL[i] += adderL[i];
       this.chR[i] += adderR[i];
     }
@@ -47,5 +51,19 @@ public class AudioChannels {
 
   int getR(int i) {
     return chR[i];
+  }
+
+  void printMax() {
+    int l = findMax(chL);
+    int r = findMax(chR);
+    Log.d(TAG, "printMax: L>" + l + ", R>" + r);
+  }
+
+  private static int findMax(int[] sig) {
+    int l = 0;
+    for (int c : sig) {
+      l = Math.max(l, c);
+    }
+    return l;
   }
 }

--- a/app/src/main/java/com/freshdigitable/ohlplayer/AudioChannels.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/AudioChannels.java
@@ -56,14 +56,16 @@ public class AudioChannels {
   void printMax() {
     int l = findMax(chL);
     int r = findMax(chR);
-    Log.d(TAG, "printMax: L>" + l + ", R>" + r);
+    if (l > 30000 || r > 30000) {
+      Log.d(TAG, "printMax: L>" + l + ", R>" + r);
+    }
   }
 
   private static int findMax(int[] sig) {
-    int l = 0;
+    long l = 0;
     for (int c : sig) {
-      l = Math.max(l, c);
+      l = Math.max(l, c * c);
     }
-    return l;
+    return (int) Math.sqrt(l);
   }
 }

--- a/app/src/main/java/com/freshdigitable/ohlplayer/CenterHRTFConvoTask.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/CenterHRTFConvoTask.java
@@ -56,4 +56,9 @@ public class CenterHRTFConvoTask implements ConvoTask {
       return new AudioChannels(0);
     }
   }
+
+  @Override
+  public void release() {
+    executor.shutdown();
+  }
 }

--- a/app/src/main/java/com/freshdigitable/ohlplayer/ComplexArray.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/ComplexArray.java
@@ -40,7 +40,18 @@ public class ComplexArray {
     }
   }
 
+  public ComplexArray(double[] sig, int size) {
+    this(size);
+    System.arraycopy(sig, 0, this.real, 0, sig.length);
+  }
+
   static ComplexArray calcFFT(int[] sig, int fftSize) {
+    final ComplexArray res = new ComplexArray(sig, fftSize);
+    res.fft();
+    return res;
+  }
+
+  static ComplexArray calcFFT(double[] sig, int fftSize) {
     final ComplexArray res = new ComplexArray(sig, fftSize);
     res.fft();
     return res;

--- a/app/src/main/java/com/freshdigitable/ohlplayer/ConvoTask.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/ConvoTask.java
@@ -6,4 +6,6 @@ package com.freshdigitable.ohlplayer;
 
 public interface ConvoTask {
   AudioChannels convo(short[] input);
+
+  void release();
 }

--- a/app/src/main/java/com/freshdigitable/ohlplayer/ImpulseResponse.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/ImpulseResponse.java
@@ -31,7 +31,7 @@ public class ImpulseResponse {
     bb.asDoubleBuffer().get(doubleBuf);
     System.arraycopy(doubleBuf, 190, res, 0, res.length);
     for (int i=0;i<res.length;i++) {
-      res[i] *= 5;
+      res[i] *= 4;
     }
     return new ImpulseResponse(res);
   }

--- a/app/src/main/java/com/freshdigitable/ohlplayer/ImpulseResponse.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/ImpulseResponse.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Callable;
  * Created by akihit on 2015/04/18.
  */
 public class ImpulseResponse {
-  private final int[] impulseRes;
+  private final double[] impulseRes;
 
   public static ImpulseResponse loadImpulseResponse(AssetFileDescriptor afd) throws IOException {
     ByteBuffer bb = ByteBuffer.allocate((int) afd.getLength()).order(ByteOrder.LITTLE_ENDIAN);
@@ -27,13 +27,13 @@ public class ImpulseResponse {
       }
     }
     bb.flip();
-    double[] doubleBuf = new double[bufSize / 8];
+    double[] doubleBuf = new double[bufSize / 8], res = new double[1400];
     bb.asDoubleBuffer().get(doubleBuf);
-    int[] ir = new int[1400];
-    for (int i = 0; i < ir.length; i++) {
-      ir[i] = (int) (doubleBuf[i + 190] * 32768.0);
+    System.arraycopy(doubleBuf, 190, res, 0, res.length);
+    for (int i=0;i<res.length;i++) {
+      res[i] *= 5;
     }
-    return new ImpulseResponse(ir);
+    return new ImpulseResponse(res);
   }
 
   private ComplexArray hrtf = new ComplexArray(0);
@@ -66,7 +66,7 @@ public class ImpulseResponse {
     };
   }
 
-  private ImpulseResponse(int[] ir) {
+  private ImpulseResponse(double[] ir) {
     this.impulseRes = ir;
   }
 

--- a/app/src/main/java/com/freshdigitable/ohlplayer/OHLAudioProcessor.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/OHLAudioProcessor.java
@@ -25,7 +25,8 @@ public class OHLAudioProcessor implements AudioProcessor {
   }
 
   @Override
-  public boolean configure(int sampleRateHz, int channelCount, int encoding) throws UnhandledFormatException {
+  public boolean configure(int sampleRateHz, int channelCount, int encoding)
+      throws UnhandledFormatException {
     if (encoding != C.ENCODING_PCM_16BIT) {
       throw new UnhandledFormatException(sampleRateHz, channelCount, encoding);
     }
@@ -83,8 +84,8 @@ public class OHLAudioProcessor implements AudioProcessor {
   private void thru(ShortBuffer shortBuffer) {
     final int size = Math.min(buf.remaining() / 4, tail.size());
     for (int i = 0; i < size; i++) {
-      buf.putShort((short) (tail.getL(i) / VOLUME + shortBuffer.get(i * 2)));
-      buf.putShort((short) (tail.getR(i) / VOLUME + shortBuffer.get(i * 2 + 1)));
+      buf.putShort((short) (tail.getL(i) + shortBuffer.get(i * 2)));
+      buf.putShort((short) (tail.getR(i) + shortBuffer.get(i * 2 + 1)));
     }
     for (int i = size * 2; i < shortBuffer.remaining(); i++) {
       buf.putShort(shortBuffer.get(i));
@@ -109,9 +110,10 @@ public class OHLAudioProcessor implements AudioProcessor {
     shortBuffer.get(inBuf);
     final AudioChannels audioChannels = convoTask.convo(inBuf);
     audioChannels.add(tail);
+    audioChannels.printMax();
     for (int i = 0; i < inputSize; i++) {
-      buf.putShort((short) (audioChannels.getL(i) / VOLUME));
-      buf.putShort((short) (audioChannels.getR(i) / VOLUME));
+      buf.putShort((short) audioChannels.getL(i));
+      buf.putShort((short) audioChannels.getR(i));
     }
     if (tail.size() != audioChannels.size() - inputSize) {
       tail = new AudioChannels(audioChannels.size() - inputSize);
@@ -147,6 +149,7 @@ public class OHLAudioProcessor implements AudioProcessor {
   @Override
   public void release() {
     inputEnded = false;
+    convoTask.release();
   }
 
   private boolean enabled = false;

--- a/app/src/main/java/com/freshdigitable/ohlplayer/OHLAudioProcessor.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/OHLAudioProcessor.java
@@ -110,7 +110,7 @@ public class OHLAudioProcessor implements AudioProcessor {
     shortBuffer.get(inBuf);
     final AudioChannels audioChannels = convoTask.convo(inBuf);
     audioChannels.add(tail);
-    audioChannels.printMax();
+//    audioChannels.printMax();
     for (int i = 0; i < inputSize; i++) {
       buf.putShort((short) audioChannels.getL(i));
       buf.putShort((short) audioChannels.getR(i));

--- a/app/src/main/java/com/freshdigitable/ohlplayer/StereoHRTFConvoTask.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/StereoHRTFConvoTask.java
@@ -81,6 +81,11 @@ public class StereoHRTFConvoTask implements ConvoTask {
     };
   }
 
+  @Override
+  public void release() {
+    executor.shutdown();
+  }
+
   public static StereoHRTFConvoTask create(Context context) throws IOException {
     final ImpulseResponse hrirL30L = ImpulseResponse.loadImpulseResponse(context.getAssets().openFd("impL30L_44100.DDB"));
     final ImpulseResponse hrirL30R = ImpulseResponse.loadImpulseResponse(context.getAssets().openFd("impL30R_44100.DDB"));

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 26 19:58:31 JST 2017
+#Fri May 19 01:16:34 JST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip


### PR DESCRIPTION
- スレッドプールをshutdownするために`ConvoTask.release()`メソッドを追加した
- hrirの倍率を小さくし、畳み込んだ後に割り算しなくていいようにした