### PR TITLE
ExoPlayer 2.4.1 へアップデート

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,13 +25,15 @@ android {
 }
 
 def supportLibVer = '25.3.1'
+def exoplayerVer = 'r2.4.1'
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.google.android.exoplayer:exoplayer:r2.3.1'
+    compile "com.google.android.exoplayer:exoplayer-core:$exoplayerVer"
+    compile "com.google.android.exoplayer:exoplayer-ui:$exoplayerVer"
     compile "com.android.support:appcompat-v7:$supportLibVer"
     compile "com.android.support:recyclerview-v7:$supportLibVer"
     compile 'com.android.support.constraint:constraint-layout:1.0.2'

--- a/app/src/main/java/com/freshdigitable/ohlplayer/MusicPlayerActivity.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/MusicPlayerActivity.java
@@ -13,7 +13,8 @@ import android.widget.CompoundButton;
 import android.widget.Switch;
 import android.widget.TextView;
 
-import com.google.android.exoplayer2.DefaultLoadControl;
+import com.google.android.exoplayer2.DefaultRenderersFactory;
+import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.audio.AudioProcessor;
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
@@ -27,9 +28,6 @@ import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.util.Util;
 
 import java.io.IOException;
-
-import static com.google.android.exoplayer2.ExoPlayerFactory.DEFAULT_ALLOWED_VIDEO_JOINING_TIME_MS;
-import static com.google.android.exoplayer2.SimpleExoPlayer.EXTENSION_RENDERER_MODE_OFF;
 
 public class MusicPlayerActivity extends AppCompatActivity {
   private static final String TAG = MusicPlayerActivity.class.getSimpleName();
@@ -135,14 +133,13 @@ public class MusicPlayerActivity extends AppCompatActivity {
   private static SimpleExoPlayer createPlayer(@NonNull Context context,
                                               @NonNull final OHLAudioProcessor ohlAudioProcessor) {
     final TrackSelector trackSelector = new DefaultTrackSelector();
-    final DefaultLoadControl loadControl = new DefaultLoadControl();
-    return new SimpleExoPlayer(context, trackSelector, loadControl, null,
-        EXTENSION_RENDERER_MODE_OFF, DEFAULT_ALLOWED_VIDEO_JOINING_TIME_MS) {
+    final DefaultRenderersFactory renderersFactory = new DefaultRenderersFactory(context) {
       @Override
       protected AudioProcessor[] buildAudioProcessors() {
         return new AudioProcessor[]{ohlAudioProcessor};
       }
     };
+    return ExoPlayerFactory.newSimpleInstance(renderersFactory, trackSelector);
   }
 
   private static final String USER_AGENT_NAME = "ohlplayer";

--- a/app/src/main/java/com/freshdigitable/ohlplayer/OHLAudioProcessor.java
+++ b/app/src/main/java/com/freshdigitable/ohlplayer/OHLAudioProcessor.java
@@ -151,7 +151,7 @@ public class OHLAudioProcessor implements AudioProcessor {
   }
 
   @Override
-  public void release() {
+  public void reset() {
     inputEnded = false;
     convoTask.release();
   }


### PR DESCRIPTION
SimpleExoPlayerインスタンスの作り方が変わったのでこれに合わせて修正した。
- DefaultRenderersFactoryを継承した匿名クラスにAudioProcessorを渡す
- AudioProcessor.release() -> AudioProcessor.reset()

refs: #20 